### PR TITLE
Fix parsing token expiration time and small cleanup

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -1,4 +1,4 @@
-package oauth2device
+package oauth2device_test
 
 import (
 	"fmt"

--- a/oauth2device.go
+++ b/oauth2device.go
@@ -89,10 +89,11 @@ func RequestDeviceCode(client *http.Client, config *Config) (*DeviceCode, error)
 	scopes := strings.Join(config.Scopes, " ")
 	resp, err := client.PostForm(config.DeviceEndpoint.CodeURL,
 		url.Values{"client_id": {config.ClientID}, "scope": {scopes}})
-
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf(
 			"request for device code authorisation returned status %v (%v)",
@@ -125,6 +126,8 @@ func WaitForDeviceAuthorization(client *http.Client, config *Config, code *Devic
 		if err != nil {
 			return nil, err
 		}
+		defer resp.Body.Close()
+
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("HTTP error %v (%v) when polling for OAuth token",
 				resp.StatusCode, http.StatusText(resp.StatusCode))


### PR DESCRIPTION
This fixes a bug where oauth2device wasn't properly passing along the token expiration to the oauth2 library. That library expects there to be a field named `Expiry`, which is the concrete time it expires, rather than a relative time. This resulted in the oauth2 not renewing the tokens when they actually expired.

It also makes sure to close the bodies, and breaks a dependency cycle running the tests.